### PR TITLE
Fix HTMLIngestor to use print() instead of undefined self.print()

### DIFF
--- a/nlm_ingestor/ingestor/html_ingestor.py
+++ b/nlm_ingestor/ingestor/html_ingestor.py
@@ -33,7 +33,7 @@ class HTMLIngestor:
         self.json_dict = br.render_json()
 
     def parse_blocks(self):
-        self.print("parsing html file")
+        print("parsing html file")
 
         header_tags = ["h1", "h2", "h3", "h4", "h5", "h6"]
         para_tags = ["p", "span"]


### PR DESCRIPTION
Resolves `AttributeError` in doc/docx processing by replacing `self.print()` with `print()` in `HTMLIngestor.parse_blocks()`
